### PR TITLE
Define xrange() in Python 3

### DIFF
--- a/ridrelay.py
+++ b/ridrelay.py
@@ -18,6 +18,11 @@ from impacket.examples.ntlmrelayx.utils.config import NTLMRelayxConfig
 from impacket.examples.ntlmrelayx.utils.targetsutils import TargetsProcessor
 from impacket.smbconnection import SMBConnection
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 getting_usernames = False
 got_usernames = False
 


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of a reworked version of __range()__.  This modification ensures equivalent functionality in both Python 2 and Python 3.