### PR TITLE
Fix encoding

### DIFF
--- a/ridrelay.py
+++ b/ridrelay.py
@@ -101,7 +101,7 @@ class SMBAttack(Thread):
                         SID_NAME_USE.enumItems(item['Use']).name)
                     print(line)
                     if fh:
-                        fh.write(line + '\n')
+                        fh.write(line.encode('utf-8') + '\n')
 
             soFar += SIMULTANEOUS
 


### PR DESCRIPTION
When outputing to file, the retrieved name is concatenated to newline
character without encoding properly. For instance, the tool crashes when
encountering the 'invité' account (Guest in French).